### PR TITLE
ci: transfer to org + keep build on GitHub-hosted

### DIFF
--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: jg-homelab-runners
     permissions:
       contents: read
       packages: write
@@ -27,6 +27,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      # Self-hosted dind runners (jg-homelab-runners) have no binfmt registered,
+      # unlike GitHub-hosted ubuntu-latest. Required for the linux/arm64 stage.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -64,7 +69,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   security-scan:
-    runs-on: ubuntu-latest
+    runs-on: jg-homelab-runners
     needs: build-and-push
     permissions:
       contents: read

--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -17,7 +17,10 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: jg-homelab-runners
+    # GitHub-hosted: this repo is public, and the org self-hosted runner group
+    # (jg-homelab-runners) disallows public repos. Low-frequency build, kept on
+    # hosted minutes. Image still publishes to the org GHCR (IMAGE_NAME = repo).
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -28,8 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Self-hosted dind runners (jg-homelab-runners) have no binfmt registered,
-      # unlike GitHub-hosted ubuntu-latest. Required for the linux/arm64 stage.
+      # QEMU emulation for the linux/arm64 build stage.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -69,7 +71,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   security-scan:
-    runs-on: jg-homelab-runners
+    runs-on: ubuntu-latest
     needs: build-and-push
     permissions:
       contents: read


### PR DESCRIPTION
pia transferred to jg-homelab. Build stays on `ubuntu-latest` (GitHub-hosted): this repo is public and the org self-hosted runner group disallows public repos. Image continues publishing to the org GHCR (`ghcr.io/jg-homelab/pia-qb-port-helper`). Added explicit `setup-qemu` for the arm64 stage.