### PR TITLE
ci(security-scan): GHCR login so Trivy can pull the private image

### DIFF
--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -77,8 +77,17 @@ jobs:
       contents: read
       security-events: write
       actions: read
+      packages: read
 
     steps:
+      # The GHCR package is private; Trivy must authenticate to pull it.
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:


### PR DESCRIPTION
The `security-scan` job never logged in to ghcr.io, so Trivy 401'd pulling the now-private org package. Adds `docker/login-action` + `packages: read`.